### PR TITLE
Fix safe prime generation

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,6 +51,7 @@ pub fn generate_safe_prime(rng: &mut impl RngCore, bits: u32) -> Integer {
     loop {
         x.assign(Integer::random_bits(bits - 1, &mut rng));
         x.set_bit(bits - 2, true);
+        x.next_prime_mut();
         x <<= 1;
         x += 1;
 


### PR DESCRIPTION
Safe prime generation should sample a prime `x`, and return `2x+1` if it's prime. Turned out that `x` was not checked to be a prime. This PR fixes prime generation.