### PR TITLE
Update rug and remove IntegerExt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 
 .helix/
+.rstags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rug = { version = "1.20", default-features = false, features = ["integer", "rand"] }
+rug = { version = "1.21", default-features = false, features = ["integer", "rand"] }
 
 rand_core = "0.6"
 

--- a/src/encryption_key.rs
+++ b/src/encryption_key.rs
@@ -1,7 +1,6 @@
 use rand_core::{CryptoRng, RngCore};
 use rug::{Complete, Integer};
 
-use crate::utils::IntegerExt;
 use crate::{utils, Ciphertext, Nonce, Plaintext};
 use crate::{Bug, Error, Reason};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -61,23 +61,6 @@ pub fn generate_safe_prime(rng: &mut impl RngCore, bits: u32) -> Integer {
     }
 }
 
-/// Provides functionality that's yet missing in [`rug::Integer`]
-pub trait IntegerExt {
-    /// Returns `self mod module`
-    fn modulo(&self, module: &Self) -> Self;
-}
-
-impl IntegerExt for Integer {
-    fn modulo(&self, module: &Self) -> Self {
-        let c = (self % module).complete();
-        if c.cmp0().is_lt() {
-            module + c
-        } else {
-            c
-        }
-    }
-}
-
 /// Faster exponentiation `x^e mod N^2` when factorization of `N = pq` is known and `e` is fixed
 pub trait FactorizedExp: Sized {
     /// Precomputes data for exponentiation

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,4 @@
-use fast_paillier::{
-    utils::{self, IntegerExt},
-    DecryptionKey,
-};
+use fast_paillier::{utils, DecryptionKey};
 use rug::{Complete, Integer};
 
 #[test]
@@ -174,7 +171,7 @@ fn factorized_exp() {
 
 /// Takes `x mod n` and maps result to `{-N/2, .., N/2}`
 fn signed_modulo(x: &Integer, n: &Integer) -> Integer {
-    let x = x.modulo(n);
+    let x = x.modulo_ref(n).complete();
     unsigned_mod_to_signed(x, n)
 }
 


### PR DESCRIPTION
Rug 1.21 added the `modulo` family of functions, so now the names clash and provide different behaviour. So it's better to remove the function we wrote and use the one provided by rug.