### PR TITLE
Fix panic when sieve parameter is too high

### DIFF
--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -170,7 +170,21 @@ fn safe_primes(c: &mut criterion::Criterion) {
     }
 }
 
-criterion::criterion_group!(benches, encryption, decryption, safe_primes);
+fn rng_covertion(c: &mut criterion::Criterion) {
+    let mut rng = rand_dev::DevRng::new();
+
+    let mut group = c.benchmark_group("PRNG convertion");
+
+    group.bench_function("into GMP", |b| {
+        b.iter(|| {
+            let mut gmp_rng = fast_paillier::utils::external_rand(std::hint::black_box(&mut rng));
+            let dyn_rng: &mut dyn rug::rand::MutRandState = &mut gmp_rng;
+            let _ = std::hint::black_box(dyn_rng);
+        })
+    });
+}
+
+criterion::criterion_group!(benches, encryption, decryption, safe_primes, rng_covertion);
 criterion::criterion_main!(benches);
 
 fn convert_integer_to_unknown_order(x: &Integer) -> libpaillier::unknown_order::BigNumber {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,9 +59,10 @@ pub fn generate_safe_prime(rng: &mut impl RngCore, bits: u32) -> Integer {
 /// lengths.
 pub fn sieve_generate_safe_primes(rng: &mut impl RngCore, bits: u32, amount: usize) -> Integer {
     use rug::integer::IsPrime;
+
+    let amount = amount.min(small_primes::SMALL_PRIMES.len());
     let mut rng = external_rand(rng);
     let mut x = Integer::new();
-    let mut mod_result = Integer::new();
 
     'trial: loop {
         // generate an odd number of length `bits - 2`
@@ -71,8 +72,8 @@ pub fn sieve_generate_safe_primes(rng: &mut impl RngCore, bits: u32, amount: usi
         x.set_bit(bits - 2, true);
         x |= 1u32;
 
-        for small_prime in &small_primes::SMALL_PRIMES[0..amount] {
-            mod_result.assign(&x % small_prime);
+        for &small_prime in &small_primes::SMALL_PRIMES[0..amount] {
+            let mod_result = x.mod_u(small_prime);
             if mod_result == (small_prime - 1) / 2 {
                 continue 'trial;
             }


### PR DESCRIPTION
* Fixes panic that can be caused by setting sieve parameter to value that exceeds the size of table of precomputed small primes
* Small optimization by using `mod_u` instead of `%` which saves an allocation
* Adds a benchmark for conversion of regular PRNG into GMP PRNG