### PR TITLE
Remove direct dependency on std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Install wasm32-unknown-unknown toolchain
       run: rustup target add wasm32-unknown-unknown
     - name: Build
-      run: |
-        cargo check -p fast-paillier --no-default-features -F backend-num-bigint,no_std,serde --target wasm32-unknown-unknown
+      run: >
+        cargo check -p fast-paillier
+          --no-default-features
+          --features backend-num-bigint,no_std,serde
+          --target wasm32-unknown-unknown
 
   check-fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,10 +61,10 @@ jobs:
     - name: Install wasm32-unknown-unknown toolchain
       run: rustup target add wasm32-unknown-unknown
     - name: Build
-      run: >
-        cargo check -p fast-paillier
-          --no-default-features
-          --features backend-num-bigint,no_std,serde
+      run: |
+        cargo check -p fast-paillier \
+          --no-default-features \
+          --features backend-num-bigint,no_std,serde \
           --target wasm32-unknown-unknown
 
   check-fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,9 +46,23 @@ jobs:
         cache-on-failure: "true"
     - name: Build
       run: |
-        cargo build --no-default-features --features backend-rug
-        cargo build --no-default-features --features backend-num-bigint
+        cargo build --no-default-features --features backend-rug,std
+        cargo build --no-default-features --features backend-num-bigint,std
+        cargo build --no-default-features --features backend-num-bigint,no_std
         cargo build --all-features
+
+  build-wasm-nostd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - name: Install wasm32-unknown-unknown toolchain
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build
+      run: |
+        cargo check -p fast-paillier --no-default-features -F backend-num-bigint,no_std,serde --target wasm32-unknown-unknown
 
   check-fmt:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v0.2.1
+## v0.3.0
 * Crate is now `#[no_std]` friendly as long as you enable `no_std` feature, and you use only
   these features: `backend-num-bigint`, `serde`. Enabling other features will introduce transitive
   dependency on `std`.
+* Breaking change in Integer API in a part where we do not offer any stability
 
 See [#20](https://github.com/LFDT-Lockness/fast-paillier/pull/20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.2.1
 * Crate is now `#[no_std]` friendly as long as you enable `no_std` feature, and you use only
-  these features: `backend-num-bigint`, `serde`. Enabling other features will intoduce transitive
+  these features: `backend-num-bigint`, `serde`. Enabling other features will introduce transitive
   dependency on `std`.
 
 See [#20](https://github.com/LFDT-Lockness/fast-paillier/pull/20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.2.1
+* Crate is now `#[no_std]` friendly as long as you enable `no_std` feature, and you use only
+  these features: `backend-num-bigint`, `serde`. Enabling other features will intoduce transitive
+  dependency on `std`.
+
+See [#20](https://github.com/LFDT-Lockness/fast-paillier/pull/20)
+
 ## v0.2.0
 * Change big integer backend to be abstract, selectable between rug and num-bigint [#18]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version = "0.8", optional = true, default-features = false }
 
 rand_core = "0.6"
 
-thiserror = "1"
+thiserror = "2"
 
 serde = { version = "1", optional = true, features = ["derive"] }
 quickcheck = { version = "1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-paillier"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Optimized Paillier encryption scheme"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ bytemuck = { version = "1.5", features = ["derive"], optional = true }
 num-bigint = { version = "0.4.6", optional = true, default-features = false, features = ["rand"] }
 num-traits = { version = "0.2.19", optional = true, default-features = false }
 num-integer = { version = "0.1.46", optional = true, default-features = false }
-glass_pumpkin = { version = "1.7", optional = true }
+glass_pumpkin = { version = "1.8", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 
 rand_core = "0.6"
 
-thiserror = "2"
+thiserror = { version = "2", default-features = false }
 
 serde = { version = "1", optional = true, default-features = false, features = ["derive", "alloc"] }
 quickcheck = { version = "1", optional = true, default-features = false }
@@ -43,7 +43,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 libpaillier = { version = "0.5", default-features = false, features = ["gmp"] }
 
 [features]
-default = ["backend-num-bigint"]
+default = ["backend-num-bigint", "std"]
+
+std = ["glass_pumpkin?/std"]
+no_std = ["glass_pumpkin?/no_std"]
 
 serde = ["dep:serde"]
 quickcheck = ["dep:quickcheck"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-paillier"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Optimized Paillier encryption scheme"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ keywords = ["paillier", "public-key", "encryption"]
 rug = { version = "1.24", optional = true, default-features = false, features = ["std", "integer", "rand"] }
 bytemuck = { version = "1.5", features = ["derive"], optional = true }
 # Deps for num-bigint
-num-bigint = { version = "0.4.6", optional = true, default-features = false, features = ["std", "rand"] }
-num-traits = { version = "0.2.19", optional = true }
-num-integer = { version = "0.1.46", optional = true }
+num-bigint = { version = "0.4.6", optional = true, default-features = false, features = ["rand"] }
+num-traits = { version = "0.2.19", optional = true, default-features = false }
+num-integer = { version = "0.1.46", optional = true, default-features = false }
 glass_pumpkin = { version = "1.7", optional = true }
 rand = { version = "0.8", optional = true, default-features = false }
 
@@ -25,7 +25,7 @@ rand_core = "0.6"
 
 thiserror = "2"
 
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive", "alloc"] }
 quickcheck = { version = "1", optional = true, default-features = false }
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ additional functionality to it will not be added. However, you can convert them
 to bytes or, if using a fixed backend, to the underlying format, and perform
 the necessary operations with those.
 
+## `#![no_std]` support
+Library is `#![no_std]`-friendly as long as you enable `no_std` feature, and you use only these
+features: `backend-num-bigint`, `serde`. Enabling other features will introduce transitive
+dependency on `std`.
+
 ## Join us in Discord!
 Feel free to reach out to us [in Discord]!
 

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -152,7 +152,7 @@ pub fn naive_safe_prime(rng: &mut impl rand_core::RngCore, bits: u32) -> Integer
         x <<= 1;
         x += 1;
 
-        if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25) {
+        if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25, rng) {
             return x;
         }
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -175,7 +175,7 @@ mod serialize {
     #[derive(serde::Serialize, serde::Deserialize)]
     struct DictFormat<'a> {
         radix: u16,
-        value: std::borrow::Cow<'a, str>,
+        value: alloc::borrow::Cow<'a, str>,
     }
 
     macro_rules! make_serde {
@@ -212,6 +212,9 @@ mod serialize {
 
     #[cfg(test)]
     mod test {
+        #[cfg(feature = "backend-rug")]
+        use alloc::{string::ToString, vec::Vec};
+
         use crate::backend::Integer;
 
         #[cfg(feature = "backend-rug")]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -139,10 +139,10 @@ pub fn sieve_generate_safe_primes(
         }
 
         // 25 taken same as one used in mpz_nextprime
-        if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25) {
+        if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25, rng) {
             x <<= 1;
             x += 1;
-            if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25) {
+            if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25, rng) {
                 return x;
             }
         }

--- a/src/backend/macro_defs.rs
+++ b/src/backend/macro_defs.rs
@@ -8,13 +8,13 @@
 /// will pass nothing
 macro_rules! make_ops_for_primitive {
     ($type:ident, $class:ident, $method:ident, $prim:ty $(,)? $(, $complete:ident)?) => {
-        impl std::ops:: $class <$prim> for $type {
+        impl core::ops:: $class <$prim> for $type {
             type Output = $type;
             fn $method(self, rhs: $prim) -> $type {
                 $type(self.0.$method(rhs))
             }
         }
-        impl std::ops:: $class <$prim> for &$type {
+        impl core::ops:: $class <$prim> for &$type {
             type Output = $type;
             fn $method(self, rhs: $prim) -> $type {
                 $type(
@@ -31,7 +31,7 @@ macro_rules! make_ops_for_primitive {
 /// nothing
 macro_rules! make_rev_ops_for_primitive {
     ($type:ident, $class:ident, $method:ident, $prim:ty, $($complete:ident)?) => {
-        impl std::ops:: $class <$type> for $prim {
+        impl core::ops:: $class <$type> for $prim {
             type Output = $type;
             fn $method(self, rhs: $type) -> $type {
                 $type(
@@ -40,7 +40,7 @@ macro_rules! make_rev_ops_for_primitive {
                 )
             }
         }
-        impl std::ops:: $class <&$type> for $prim {
+        impl core::ops:: $class <&$type> for $prim {
             type Output = $type;
             fn $method(self, rhs: &$type) -> $type {
                 $type(
@@ -57,7 +57,7 @@ macro_rules! make_rev_ops_for_primitive {
 /// `BigInt::from` for bitwise arithmetic operations, rug will pass nothing
 macro_rules! make_assign_for_primitive {
     ($type:ident, $class:ident, $method:ident, $prim:ty $(,)? $(, $from:expr)?) => {
-        impl std::ops:: $class <$prim> for $type {
+        impl core::ops:: $class <$prim> for $type {
             fn $method(&mut self, rhs: $prim) {
                 $( let rhs = $from(rhs); )?
                 self.0.$method(rhs)
@@ -71,25 +71,25 @@ macro_rules! make_assign_for_primitive {
 macro_rules! make_ops {
     ($type:ident, $class:ident, $method:ident $(, $complete:ident)?) => {
         // All options with self
-        impl std::ops:: $class <$type> for $type {
+        impl core::ops:: $class <$type> for $type {
             type Output = $type;
             fn $method(self, rhs: $type) -> $type {
                 $type(self.0.$method(rhs.0))
             }
         }
-        impl std::ops:: $class <$type> for &$type {
+        impl core::ops:: $class <$type> for &$type {
             type Output = $type;
             fn $method(self, rhs: $type) -> $type {
                 $type((&self.0).$method(rhs.0))
             }
         }
-        impl std::ops:: $class <&$type> for $type {
+        impl core::ops:: $class <&$type> for $type {
             type Output = $type;
             fn $method(self, rhs: &$type) -> $type {
                 $type(self.0.$method(&rhs.0))
             }
         }
-        impl std::ops:: $class <&$type> for &$type {
+        impl core::ops:: $class <&$type> for &$type {
             type Output = $type;
             fn $method(self, rhs: &$type) -> $type {
                 $type(
@@ -126,12 +126,12 @@ macro_rules! make_ops {
 /// primitives
 macro_rules! make_assign {
     ($type:ident, $class:ident, $method:ident) => {
-        impl std::ops::$class<$type> for $type {
+        impl core::ops::$class<$type> for $type {
             fn $method(&mut self, rhs: $type) {
                 self.0.$method(rhs.0)
             }
         }
-        impl std::ops::$class<&$type> for $type {
+        impl core::ops::$class<&$type> for $type {
             fn $method(&mut self, rhs: &$type) {
                 self.0.$method(&rhs.0)
             }
@@ -171,13 +171,13 @@ macro_rules! make_all_ops {
         $crate::backend::macro_defs::make_ops_for_primitive!(Integer, Shr, shr, i32 $(, $complete)?);
         $crate::backend::macro_defs::make_ops_for_primitive!(Integer, Shr, shr, usize $(, $complete)?);
 
-        impl std::ops::Neg for $type {
+        impl core::ops::Neg for $type {
             type Output = $type;
             fn neg(self) -> Self::Output {
                 $type(self.0.neg())
             }
         }
-        impl std::ops::Neg for & $type {
+        impl core::ops::Neg for & $type {
             type Output = $type;
             fn neg(self) -> Self::Output {
                 let r = (-&self.0)
@@ -208,8 +208,8 @@ macro_rules! make_all_ops {
             }
         }
 
-        impl std::fmt::Display for $type {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl core::fmt::Display for $type {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 self.0.fmt(f)
             }
         }

--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -269,10 +269,10 @@ impl Integer {
     }
 
     // TODO reps is unused here, need to unify with rug
-    pub fn is_probably_prime(&self, _reps: u32) -> IsPrime {
+    pub fn is_probably_prime(&self, _reps: u32, rng: &mut impl rand_core::RngCore) -> IsPrime {
         if self.cmp0().is_le() {
             IsPrime::No
-        } else if glass_pumpkin::prime::check(self.0.magnitude()) {
+        } else if glass_pumpkin::prime::check_with(self.0.magnitude(), rng) {
             IsPrime::Yes
         } else {
             IsPrime::No
@@ -407,7 +407,8 @@ mod test {
         for _ in 0..4096 {
             let mut r = Integer::random_bits(len, rng);
             r.set_bit(0, true);
-            if r.is_probably_prime(25) != super::IsPrime::No && super::last_limb(&r.0) % 4 == 3 {
+            if r.is_probably_prime(25, rng) != super::IsPrime::No && super::last_limb(&r.0) % 4 == 3
+            {
                 return r;
             }
         }

--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)]
 
+use alloc::{string::String, vec::Vec};
+
 use super::IsPrime;
 use num_integer::Integer as _;
 use num_traits::Signed as _;
@@ -112,7 +114,7 @@ impl Integer {
         let (_sign, val) = self.0.into_parts();
         Self(num_bigint::BigInt::from(val))
     }
-    pub fn cmp_abs(&self, other: &Self) -> std::cmp::Ordering {
+    pub fn cmp_abs(&self, other: &Self) -> core::cmp::Ordering {
         self.0.magnitude().cmp(other.0.magnitude())
     }
 
@@ -123,11 +125,11 @@ impl Integer {
         Integer(self.0.gcd(&other.0))
     }
 
-    pub fn cmp0(&self) -> std::cmp::Ordering {
+    pub fn cmp0(&self) -> core::cmp::Ordering {
         match self.0.sign() {
-            num_bigint::Sign::NoSign => std::cmp::Ordering::Equal,
-            num_bigint::Sign::Plus => std::cmp::Ordering::Greater,
-            num_bigint::Sign::Minus => std::cmp::Ordering::Less,
+            num_bigint::Sign::NoSign => core::cmp::Ordering::Equal,
+            num_bigint::Sign::Plus => core::cmp::Ordering::Greater,
+            num_bigint::Sign::Minus => core::cmp::Ordering::Less,
         }
     }
     pub fn sign(&self) -> super::Sign {
@@ -384,9 +386,9 @@ impl quickcheck::Arbitrary for Integer {
         Integer::from_bytes_msf_signed(&bytes, sign)
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+    fn shrink(&self) -> alloc::boxed::Box<dyn Iterator<Item = Self>> {
         let mut prev = self.clone();
-        Box::new(std::iter::from_fn(move || {
+        alloc::boxed::Box::new(core::iter::from_fn(move || {
             if prev.cmp0().is_eq() {
                 None
             } else {

--- a/src/backend/rug.rs
+++ b/src/backend/rug.rs
@@ -231,7 +231,7 @@ impl Integer {
         rug::Assign::assign(&mut self.0, r)
     }
 
-    pub fn is_probably_prime(&self, reps: u32) -> IsPrime {
+    pub fn is_probably_prime(&self, reps: u32, _rng: &mut impl rand_core::RngCore) -> IsPrime {
         if self.cmp0().is_le() {
             return IsPrime::No;
         }
@@ -249,7 +249,7 @@ impl Integer {
             x.assign_random_bits(bit_size, rng);
             x.set_bit(bit_size - 1, true);
             x |= 1u32;
-            if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25) {
+            if let IsPrime::Yes | IsPrime::Probably = x.is_probably_prime(25, rng) {
                 return x;
             }
         }

--- a/src/backend/rug.rs
+++ b/src/backend/rug.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)]
 
+use alloc::{string::String, vec::Vec};
+
 use super::IsPrime;
 use rug::Complete;
 
@@ -103,7 +105,7 @@ impl Integer {
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
-    pub fn cmp_abs(&self, other: &Self) -> std::cmp::Ordering {
+    pub fn cmp_abs(&self, other: &Self) -> core::cmp::Ordering {
         self.0.cmp_abs(&other.0)
     }
 
@@ -114,12 +116,12 @@ impl Integer {
         Integer(self.0.gcd_ref(&other.0).complete())
     }
 
-    pub fn cmp0(&self) -> std::cmp::Ordering {
+    pub fn cmp0(&self) -> core::cmp::Ordering {
         self.0.cmp0()
     }
     pub fn sign(&self) -> super::Sign {
         match self.cmp0() {
-            std::cmp::Ordering::Less => super::Sign::Negative,
+            core::cmp::Ordering::Less => super::Sign::Negative,
             _ => super::Sign::NonNegative,
         }
     }
@@ -292,9 +294,9 @@ impl quickcheck::Arbitrary for Integer {
         Integer::from_bytes_msf_signed(&bytes, sign)
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+    fn shrink(&self) -> alloc::boxed::Box<dyn Iterator<Item = Self>> {
         let mut prev = self.clone();
-        Box::new(std::iter::from_fn(move || {
+        alloc::boxed::Box::new(core::iter::from_fn(move || {
             if prev.cmp0().is_eq() {
                 None
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     not(test),
     warn(clippy::expect_used, clippy::unwrap_used, clippy::panic)
 )]
+#![no_std]
 
 #[cfg(test)]
 mod unused_deps {
@@ -24,6 +25,8 @@ mod unused_deps {
     }
 }
 
+extern crate alloc;
+
 pub mod backend;
 mod decryption_key;
 mod encryption_key;
@@ -32,7 +35,7 @@ pub mod utils;
 #[cfg(feature = "serde")]
 mod serde;
 
-use std::fmt;
+use core::fmt;
 
 use crate::backend::Integer;
 use rand_core::{CryptoRng, RngCore};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! Various utilities
 
-use std::fmt;
+use core::fmt;
 
 use crate::backend::Integer;
 

--- a/tests/integration/backend.rs
+++ b/tests/integration/backend.rs
@@ -36,6 +36,34 @@ macro_rules! make_quickcheck {
             }
         }
     };
+    // Similar to the previous branch, but adds a PRNG to method invocation as a last argument
+    (#[with_rng] $method:ident ( self: $self_ty:ty, $($arg:ident: $t:ty),* $(,)? ) ) => {
+        quickcheck::quickcheck! {
+            fn $method(nbi: $self_ty, $($arg: $t),*, rng: Prng) -> bool {
+                #[allow(unused_mut)]
+                let mut nbi = NbiInteger::from(nbi);
+                let (bytes, sign) = nbi.to_bytes_msf_signed();
+                #[allow(unused_mut)]
+                let mut rug = RugInteger::from_bytes_msf_signed(&bytes, sign);
+                let mut rng = rng.0;
+
+                let r1 = nbi.$method(
+                    $(
+                        Arg::to_nbi( &$arg )
+                    ),*,
+                    &mut rng,
+                );
+                let r2 = rug.$method(
+                    $(
+                        Arg::to_rug( &$arg )
+                    ),*,
+                    &mut rng,
+                );
+
+                r1.equals(r2)
+            }
+        }
+    };
     // Case for static methods. Called like `make_quickcheck!(Self::method_name(
     // arg: T2, arg2: T3))`
     //
@@ -89,7 +117,7 @@ make_quickcheck!(significant_dwords(self: NbiInteger));
 make_quickcheck!(invert(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(invert_ref(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(set_bit(self: NbiInteger, index: SmallU32, value: bool));
-make_quickcheck!(is_probably_prime(self: NbiInteger, const25: Const25));
+make_quickcheck!(#[with_rng] is_probably_prime(self: NbiInteger, const25: Const25));
 make_quickcheck!(jacobi(self: NbiInteger, n: OddPositive));
 make_quickcheck!(
     combine(
@@ -200,6 +228,7 @@ macro_rules! trivial_arg {
 trivial_arg! {
     u32,
     bool,
+    Prng,
 }
 
 ///// Newtypes for quickcheck's Arbitrary /////
@@ -386,5 +415,16 @@ where
                 break Positive(x);
             }
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Prng(rand_dev::DevRng);
+impl quickcheck::Arbitrary for Prng {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        // this seed is not going to be uniform as there's no way to sample uniform distribution
+        // from Gen
+        let seed = [0u8; 32].map(|_| u8::arbitrary(g));
+        Prng(rand_core::SeedableRng::from_seed(seed))
     }
 }

--- a/tests/integration/backend.rs
+++ b/tests/integration/backend.rs
@@ -21,44 +21,31 @@ macro_rules! make_quickcheck {
                 #[allow(unused_mut)]
                 let mut rug = RugInteger::from_bytes_msf_signed(&bytes, sign);
 
-                let r1 = nbi.$method(
+                let r1 = {
+                    // Since Arg::to_nbi takes mutable reference to the arg, we clone them,
+                    // so the `rug` method below receives the same args as provided by
+                    // quickcheck without any modification
                     $(
-                        Arg::to_nbi( &$arg ),
+                        let mut $arg = $arg.clone();
                     )*
-                );
-                let r2 = rug.$method(
+                    nbi.$method(
+                        $(
+                            Arg::to_nbi( &mut $arg ),
+                        )*
+                    )
+                };
+                let r2 = {
+                    // Change args mutability
                     $(
-                        Arg::to_rug( &$arg ),
+                        let mut $arg = $arg;
                     )*
-                );
 
-                r1.equals(r2)
-            }
-        }
-    };
-    // Similar to the previous branch, but adds a PRNG to method invocation as a last argument
-    (#[with_rng] $method:ident ( self: $self_ty:ty, $($arg:ident: $t:ty),* $(,)? ) ) => {
-        quickcheck::quickcheck! {
-            fn $method(nbi: $self_ty, $($arg: $t),*, rng: Prng) -> bool {
-                #[allow(unused_mut)]
-                let mut nbi = NbiInteger::from(nbi);
-                let (bytes, sign) = nbi.to_bytes_msf_signed();
-                #[allow(unused_mut)]
-                let mut rug = RugInteger::from_bytes_msf_signed(&bytes, sign);
-                let mut rng = rng.0;
-
-                let r1 = nbi.$method(
-                    $(
-                        Arg::to_nbi( &$arg )
-                    ),*,
-                    &mut rng,
-                );
-                let r2 = rug.$method(
-                    $(
-                        Arg::to_rug( &$arg )
-                    ),*,
-                    &mut rng,
-                );
+                    rug.$method(
+                        $(
+                            Arg::to_rug( &mut $arg ),
+                        )*
+                    )
+                };
 
                 r1.equals(r2)
             }
@@ -72,18 +59,34 @@ macro_rules! make_quickcheck {
     (Self :: $method:ident($arg:ident: $t:ty $(, $args:ident: $ts:ty)*)) => {
         quickcheck::quickcheck! {
             fn $method($arg: $t $(, $args: $ts)*) -> bool {
-                let r1 = NbiInteger::$method(
-                    Arg::to_nbi( &$arg ),
+                let r1 = {
+                    // Since Arg::to_nbi takes mutable reference to the arg, we clone them,
+                    // so the `rug` method below receives the same args as provided by
+                    // quickcheck without any modification
+                    let mut $arg = $arg.clone();
                     $(
-                        Arg::to_nbi( &$args ),
+                        let mut $args = $args.clone();
                     )*
-                );
-                let r2 = RugInteger::$method(
-                    Arg::to_rug( &$arg ),
+                    NbiInteger::$method(
+                        Arg::to_nbi( &mut $arg ),
+                        $(
+                            Arg::to_nbi( &mut $args ),
+                        )*
+                    )
+                };
+                let r2 = {
+                    // Change args mutability
+                    let mut $arg = $arg;
                     $(
-                        Arg::to_rug( &$args ),
+                        let mut $args = $args;
                     )*
-                );
+                    RugInteger::$method(
+                        Arg::to_rug( &mut $arg ),
+                        $(
+                            Arg::to_rug( &mut $args ),
+                        )*
+                    )
+                };
 
                 r1.equals(r2)
             }
@@ -117,7 +120,7 @@ make_quickcheck!(significant_dwords(self: NbiInteger));
 make_quickcheck!(invert(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(invert_ref(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(set_bit(self: NbiInteger, index: SmallU32, value: bool));
-make_quickcheck!(#[with_rng] is_probably_prime(self: NbiInteger, const25: Const25));
+make_quickcheck!(is_probably_prime(self: NbiInteger, const25: Const25, rng: Prng));
 make_quickcheck!(jacobi(self: NbiInteger, n: OddPositive));
 make_quickcheck!(
     combine(
@@ -205,8 +208,8 @@ trait Arg<'a> {
     type NbiArg;
     type RugArg;
 
-    fn to_nbi(&'a self) -> Self::NbiArg;
-    fn to_rug(&'a self) -> Self::RugArg;
+    fn to_nbi(&'a mut self) -> Self::NbiArg;
+    fn to_rug(&'a mut self) -> Self::RugArg;
 }
 
 macro_rules! trivial_arg {
@@ -215,10 +218,10 @@ macro_rules! trivial_arg {
             impl Arg<'_> for $t {
                 type NbiArg = $t;
                 type RugArg = $t;
-                fn to_nbi(&self) -> Self::NbiArg {
+                fn to_nbi(&mut self) -> Self::NbiArg {
                     self.clone()
                 }
-                fn to_rug(&self) -> Self::NbiArg {
+                fn to_rug(&mut self) -> Self::NbiArg {
                     self.clone()
                 }
             }
@@ -228,7 +231,6 @@ macro_rules! trivial_arg {
 trivial_arg! {
     u32,
     bool,
-    Prng,
 }
 
 ///// Newtypes for quickcheck's Arbitrary /////
@@ -240,10 +242,10 @@ struct RefInteger(NbiInteger, RugInteger);
 impl<'a> Arg<'a> for RefInteger {
     type NbiArg = &'a NbiInteger;
     type RugArg = &'a RugInteger;
-    fn to_nbi(&'a self) -> Self::NbiArg {
+    fn to_nbi(&'a mut self) -> Self::NbiArg {
         &self.0
     }
-    fn to_rug(&'a self) -> Self::RugArg {
+    fn to_rug(&'a mut self) -> Self::RugArg {
         &self.1
     }
 }
@@ -276,10 +278,10 @@ struct OddPositive(NbiInteger, RugInteger);
 impl<'a> Arg<'a> for OddPositive {
     type NbiArg = &'a NbiInteger;
     type RugArg = &'a RugInteger;
-    fn to_nbi(&'a self) -> Self::NbiArg {
+    fn to_nbi(&'a mut self) -> Self::NbiArg {
         &self.0
     }
-    fn to_rug(&'a self) -> Self::RugArg {
+    fn to_rug(&'a mut self) -> Self::RugArg {
         &self.1
     }
 }
@@ -308,10 +310,10 @@ struct SmallU32(u32);
 impl Arg<'_> for SmallU32 {
     type NbiArg = u32;
     type RugArg = u32;
-    fn to_nbi(&self) -> Self::NbiArg {
+    fn to_nbi(&mut self) -> Self::NbiArg {
         self.0
     }
-    fn to_rug(&self) -> Self::RugArg {
+    fn to_rug(&mut self) -> Self::RugArg {
         self.0
     }
 }
@@ -341,10 +343,10 @@ struct Const25;
 impl Arg<'_> for Const25 {
     type NbiArg = u32;
     type RugArg = u32;
-    fn to_nbi(&self) -> Self::NbiArg {
+    fn to_nbi(&mut self) -> Self::NbiArg {
         25
     }
-    fn to_rug(&self) -> Self::RugArg {
+    fn to_rug(&mut self) -> Self::RugArg {
         25
     }
 }
@@ -360,10 +362,10 @@ struct NonZero<T>(T);
 impl<'a, T: Arg<'a>> Arg<'a> for NonZero<T> {
     type NbiArg = T::NbiArg;
     type RugArg = T::RugArg;
-    fn to_nbi(&'a self) -> Self::NbiArg {
+    fn to_nbi(&'a mut self) -> Self::NbiArg {
         self.0.to_nbi()
     }
-    fn to_rug(&'a self) -> Self::RugArg {
+    fn to_rug(&'a mut self) -> Self::RugArg {
         self.0.to_rug()
     }
 }
@@ -394,10 +396,10 @@ struct Positive<T>(T);
 impl<'a, T: Arg<'a>> Arg<'a> for Positive<T> {
     type NbiArg = T::NbiArg;
     type RugArg = T::RugArg;
-    fn to_nbi(&'a self) -> Self::NbiArg {
+    fn to_nbi(&'a mut self) -> Self::NbiArg {
         self.0.to_nbi()
     }
-    fn to_rug(&'a self) -> Self::RugArg {
+    fn to_rug(&'a mut self) -> Self::RugArg {
         self.0.to_rug()
     }
 }
@@ -426,5 +428,16 @@ impl quickcheck::Arbitrary for Prng {
         // from Gen
         let seed = [0u8; 32].map(|_| u8::arbitrary(g));
         Prng(rand_core::SeedableRng::from_seed(seed))
+    }
+}
+impl<'a> Arg<'a> for Prng {
+    type NbiArg = &'a mut rand_dev::DevRng;
+    type RugArg = &'a mut rand_dev::DevRng;
+
+    fn to_nbi(&'a mut self) -> Self::NbiArg {
+        &mut self.0
+    }
+    fn to_rug(&'a mut self) -> Self::RugArg {
+        &mut self.0
     }
 }


### PR DESCRIPTION
* Make crate `#![no_std]` friendly
  * Features compatible with no_std: `backend-num-bigint`, `serde`
  * Requires `no_std` feature to be enabled
* sort of breaking change: `Integer::is_probably_prime` now accepts a `rng` as an argument, which is ignored for `rug` backend, but is used for `num-bigint`. Since we offer no stable API for Integer, it's a minor version bump
* Update CI
* Update readme

PR can be reviewed commit-by-commit.