### PR TITLE
Consistent random between backends

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,8 +36,7 @@ jobs:
         cargo bench --no-run --no-default-features --features serde,backend-rug
     - name: Run tests
       run: cargo test --no-default-features --features serde,backend-rug
-
-  build-with-different-feature-sets:
+  build-and-test-all-features:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -46,10 +45,28 @@ jobs:
         cache-on-failure: "true"
     - name: Build
       run: |
-        cargo build --no-default-features --features backend-rug,std
-        cargo build --no-default-features --features backend-num-bigint,std
-        cargo build --no-default-features --features backend-num-bigint,no_std
         cargo build --all-features
+        cargo bench --no-run --all-features
+    - name: Run tests
+      run: cargo test --all-features
+
+  build-with-different-feature-sets:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+        - "backend-rug,std"
+        - "backend-num-bigint,std"
+        - "backend-num-bigint,no_std"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-on-failure: "true"
+    - name: Build
+      run: |
+        cargo build --no-default-features --features ${{ matrix.features }}
+        cargo bench --no-run --no-default-features --features ${{ matrix.features }}
 
   build-wasm-nostd:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.3.2
+* Make `random_below`, `random_below_ref`, `random_bits`, `random_bits_signed`,
+  `assign_random_below`, `assign_random_bits` methods for both backends
+  generate the same numbers [#22]
+
+[#22]: https://github.com/LFDT-Lockness/fast-paillier/pull/22
+
 ## v0.3.1
 * Improve implementation of `num_bigint::Integer::significant_dwords` [#21]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-paillier"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Optimized Paillier encryption scheme"

--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -230,15 +230,31 @@ impl Integer {
     }
 
     pub fn random_below(self, rng: &mut impl rand_core::RngCore) -> Self {
-        let range = num_traits::ConstZero::ZERO..self.0;
-        Integer(rand::Rng::gen_range(rng, range))
+        // when the number is a power of two, the randomness generation between
+        // rug and nbi differs, and rug uses exactly the same as random_bits
+        let bits = self.0.bits() - 1;
+        if self.0.trailing_zeros() == Some(bits) {
+            Self::random_bits_u64(bits, rng)
+        } else {
+            let range = num_traits::ConstZero::ZERO..self.0;
+            Integer(rand::Rng::gen_range(rng, range))
+        }
     }
     pub fn random_below_ref(&self, rng: &mut impl rand_core::RngCore) -> Self {
-        let range = num_traits::ConstZero::ZERO..self.0.clone();
-        Integer(rand::Rng::gen_range(rng, range))
+        // see the note in random_below
+        let bits = self.0.bits() - 1;
+        if self.0.trailing_zeros() == Some(bits) {
+            Self::random_bits_u64(bits, rng)
+        } else {
+            let range = num_traits::ConstZero::ZERO..self.0.clone();
+            Integer(rand::Rng::gen_range(rng, range))
+        }
     }
     pub fn random_bits(bits: u32, rng: &mut impl rand_core::RngCore) -> Self {
-        let dist = num_bigint::RandomBits::new(bits.into());
+        Self::random_bits_u64(bits.into(), rng)
+    }
+    fn random_bits_u64(bits: u64, rng: &mut impl rand_core::RngCore) -> Self {
+        let dist = num_bigint::RandomBits::new(bits);
         let uint = rand::distributions::Distribution::sample(&dist, rng);
         Integer(num_bigint::BigInt::from_biguint(
             num_bigint::Sign::Plus,

--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -257,12 +257,22 @@ impl Integer {
         Integer(num_bigint::BigInt::from_biguint(sign, uint))
     }
 
-    pub fn assign_random_below(&mut self, modulo: &Self, rng: &mut impl rand_core::RngCore) {
+    pub fn assign_random_below(
+        &mut self,
+        modulo: &Self,
+        rng: &mut impl rand_core::RngCore,
+    ) -> &mut Self {
         *self = modulo.random_below_ref(rng);
+        self
     }
 
-    pub fn assign_random_bits(&mut self, bits: u32, rng: &mut impl rand_core::RngCore) {
+    pub fn assign_random_bits(
+        &mut self,
+        bits: u32,
+        rng: &mut impl rand_core::RngCore,
+    ) -> &mut Self {
         *self = Self::random_bits(bits, rng);
+        self
     }
 
     // TODO reps is unused here, need to unify with rug

--- a/src/backend/rug.rs
+++ b/src/backend/rug.rs
@@ -219,16 +219,26 @@ impl Integer {
         }
     }
 
-    pub fn assign_random_below(&mut self, modulo: &Self, rng: &mut impl rand_core::RngCore) {
+    pub fn assign_random_below(
+        &mut self,
+        modulo: &Self,
+        rng: &mut impl rand_core::RngCore,
+    ) -> &mut Self {
         let mut rng = external_rand(rng);
         let r = modulo.0.random_below_ref(&mut rng);
-        rug::Assign::assign(&mut self.0, r)
+        rug::Assign::assign(&mut self.0, r);
+        self
     }
 
-    pub fn assign_random_bits(&mut self, bits: u32, rng: &mut impl rand_core::RngCore) {
+    pub fn assign_random_bits(
+        &mut self,
+        bits: u32,
+        rng: &mut impl rand_core::RngCore,
+    ) -> &mut Self {
         let mut rng = external_rand(rng);
         let r = rug::Integer::random_bits(bits, &mut rng);
-        rug::Assign::assign(&mut self.0, r)
+        rug::Assign::assign(&mut self.0, r);
+        self
     }
 
     pub fn is_probably_prime(&self, reps: u32, _rng: &mut impl rand_core::RngCore) -> IsPrime {

--- a/tests/integration/backend.rs
+++ b/tests/integration/backend.rs
@@ -47,7 +47,6 @@ macro_rules! make_quickcheck {
                     )
                 };
 
-                eprintln!("equality starts");
                 r1.equals(r2)
             }
         }
@@ -121,14 +120,13 @@ make_quickcheck!(significant_dwords(self: NbiInteger));
 make_quickcheck!(invert(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(invert_ref(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(set_bit(self: NbiInteger, index: SmallU32, value: bool));
-make_quickcheck!(random_below(self: NbiInteger, rng: Prng));
-make_quickcheck!(random_below_ref(self: NbiInteger, rng: Prng));
+make_quickcheck!(random_below(self: Positive<NbiInteger>, rng: Prng));
+make_quickcheck!(random_below_ref(self: Positive<NbiInteger>, rng: Prng));
 make_quickcheck!(Self::random_bits(bits: SmallU32, rng: Prng));
 make_quickcheck!(Self::random_bits_signed(bits: SmallU32, rng: Prng));
 make_quickcheck!(assign_random_below(self: NbiInteger, modulo: Positive<RefInteger>, rng: Prng));
 make_quickcheck!(assign_random_bits(self: NbiInteger, bits: SmallU32, rng: Prng));
 make_quickcheck!(is_probably_prime(self: NbiInteger, const25: Const<25>, rng: Prng));
-make_quickcheck!(Self::generate_prime(rng: Prng, bit_size: Const<1536>));
 make_quickcheck!(jacobi(self: NbiInteger, n: OddPositive));
 make_quickcheck!(
     combine(
@@ -139,6 +137,20 @@ make_quickcheck!(
         re: RefInteger,
     )
 );
+
+#[test]
+fn round_random() {
+    let mut nbi_rng = rand_dev::DevRng::new();
+    let mut rug_rng = nbi_rng.clone();
+    let nbi = NbiInteger::from(8);
+    let rug = RugInteger::from(8);
+
+    for _ in 0..32 {
+        let nbi_random = nbi.random_below_ref(&mut nbi_rng);
+        let rug_random = rug.random_below_ref(&mut rug_rng);
+        assert!(nbi_random.equals(rug_random));
+    }
+}
 
 ///// Helper traits for macro /////
 
@@ -427,15 +439,25 @@ where
         }
     }
 }
+impl From<Positive<NbiInteger>> for NbiInteger {
+    fn from(value: Positive<NbiInteger>) -> Self {
+        value.0
+    }
+}
 
 #[derive(Clone, Debug)]
-struct Prng(rand_dev::DevRng);
+struct Prng {
+    // Used in debug impl to print the generated seed
+    _seed: [u8; 32],
+    rng: rand_dev::DevRng,
+}
 impl quickcheck::Arbitrary for Prng {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         // this seed is not going to be uniform as there's no way to sample
         // uniform distribution from Gen
         let seed = [0u8; 32].map(|_| u8::arbitrary(g));
-        Prng(rand_core::SeedableRng::from_seed(seed))
+        let rng = rand_core::SeedableRng::from_seed(seed);
+        Prng { _seed: seed, rng }
     }
 }
 impl<'a> Arg<'a> for Prng {
@@ -443,9 +465,9 @@ impl<'a> Arg<'a> for Prng {
     type RugArg = &'a mut rand_dev::DevRng;
 
     fn to_nbi(&'a mut self) -> Self::NbiArg {
-        &mut self.0
+        &mut self.rng
     }
     fn to_rug(&'a mut self) -> Self::RugArg {
-        &mut self.0
+        &mut self.rng
     }
 }

--- a/tests/integration/backend.rs
+++ b/tests/integration/backend.rs
@@ -47,6 +47,7 @@ macro_rules! make_quickcheck {
                     )
                 };
 
+                eprintln!("equality starts");
                 r1.equals(r2)
             }
         }
@@ -120,7 +121,14 @@ make_quickcheck!(significant_dwords(self: NbiInteger));
 make_quickcheck!(invert(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(invert_ref(self: NbiInteger, modulo: Positive<RefInteger>));
 make_quickcheck!(set_bit(self: NbiInteger, index: SmallU32, value: bool));
-make_quickcheck!(is_probably_prime(self: NbiInteger, const25: Const25, rng: Prng));
+make_quickcheck!(random_below(self: NbiInteger, rng: Prng));
+make_quickcheck!(random_below_ref(self: NbiInteger, rng: Prng));
+make_quickcheck!(Self::random_bits(bits: SmallU32, rng: Prng));
+make_quickcheck!(Self::random_bits_signed(bits: SmallU32, rng: Prng));
+make_quickcheck!(assign_random_below(self: NbiInteger, modulo: Positive<RefInteger>, rng: Prng));
+make_quickcheck!(assign_random_bits(self: NbiInteger, bits: SmallU32, rng: Prng));
+make_quickcheck!(is_probably_prime(self: NbiInteger, const25: Const<25>, rng: Prng));
+make_quickcheck!(Self::generate_prime(rng: Prng, bit_size: Const<1536>));
 make_quickcheck!(jacobi(self: NbiInteger, n: OddPositive));
 make_quickcheck!(
     combine(
@@ -336,23 +344,23 @@ impl quickcheck::Arbitrary for SmallU32 {
     }
 }
 
-/// Helper quickcheck newtype: generates a constant 25 u32. Convenient for the
+/// Helper quickcheck newtype: generates a constant u32. Convenient for the
 /// macros above, since they don't accept constant values
 #[derive(Clone, Debug)]
-struct Const25;
-impl Arg<'_> for Const25 {
+struct Const<const N: u32>;
+impl<const N: u32> Arg<'_> for Const<N> {
     type NbiArg = u32;
     type RugArg = u32;
     fn to_nbi(&mut self) -> Self::NbiArg {
-        25
+        N
     }
     fn to_rug(&mut self) -> Self::RugArg {
-        25
+        N
     }
 }
-impl quickcheck::Arbitrary for Const25 {
+impl<const N: u32> quickcheck::Arbitrary for Const<N> {
     fn arbitrary(_: &mut quickcheck::Gen) -> Self {
-        Const25
+        Const
     }
 }
 
@@ -424,8 +432,8 @@ where
 struct Prng(rand_dev::DevRng);
 impl quickcheck::Arbitrary for Prng {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        // this seed is not going to be uniform as there's no way to sample uniform distribution
-        // from Gen
+        // this seed is not going to be uniform as there's no way to sample
+        // uniform distribution from Gen
         let seed = [0u8; 32].map(|_| u8::arbitrary(g));
         Prng(rand_core::SeedableRng::from_seed(seed))
     }


### PR DESCRIPTION
Make the random number generating methods of both backends generate the same numbers. Add tests for that.

Prime numbers excluded from the scope because of difficulty and lack of applicability