### PR TITLE
fix(num_bigint): widen rng trait bound for glass_pumpkin >= 1.10

### DIFF
--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -292,7 +292,15 @@ impl Integer {
     }
 
     // TODO reps is unused here, need to unify with rug
-    pub fn is_probably_prime(&self, _reps: u32, rng: &mut impl rand_core::RngCore) -> IsPrime {
+    // `glass_pumpkin::prime::check_with` (>= 1.10) accepts an
+    // `R: rand_core::Rng`, which is `RngCore + DerefMut + ?Sized` under
+    // rand_core 0.9; the additional `+ DerefMut` bound on the parameter
+    // here lets the call compile. No semantic change.
+    pub fn is_probably_prime(
+        &self,
+        _reps: u32,
+        rng: &mut (impl rand_core::RngCore + core::ops::DerefMut),
+    ) -> IsPrime {
         if self.cmp0().is_le() {
             IsPrime::No
         } else if glass_pumpkin::prime::check_with(self.0.magnitude(), rng) {
@@ -302,7 +310,11 @@ impl Integer {
         }
     }
 
-    pub fn generate_prime(rng: &mut impl rand_core::RngCore, bit_size: u32) -> Self {
+    // Same trait-bound widening as `is_probably_prime` above.
+    pub fn generate_prime(
+        rng: &mut (impl rand_core::RngCore + core::ops::DerefMut),
+        bit_size: u32,
+    ) -> Self {
         let mut x = Integer::zero();
         loop {
             x.assign_random_bits(bit_size, rng);


### PR DESCRIPTION
## Summary

`fast-paillier 0.3.2` no longer compiles when cargo resolves
`glass_pumpkin = "^1.8"` to a 1.10.x version (released 2026-02-14).
The 1.10 release of `glass_pumpkin` switched its public surface to
the `rand_core` 0.9 trait shape, and the `R: rand_core::Rng` bound
under rand_core 0.9 is `RngCore + DerefMut + ?Sized`. The existing
call sites in `num_bigint::is_probably_prime` and
`num_bigint::generate_prime` declare their `rng` parameter as
`&mut impl rand_core::RngCore` and so no longer satisfy that bound:

```text
error[E0277]: the trait bound `&mut impl RngCore: DerefMut`
is not satisfied
   --> src/backend/num_bigint.rs:298:65
    |
298 |         } else if glass_pumpkin::prime::check_with(self.0.magnitude(), rng) {
```

This breaks every `cggmp24 = "0.7.0-alpha.{3,4}"` consumer
transitively (the alpha line of cggmp21 at HEAD also fails to
compile against the resolved fast-paillier closure today). The
companion `glass_pumpkin` versions 1.7 .. 1.9 cannot be used as a
fallback because their transitive `core2 = "^0.4"` is wholly yanked
from crates.io.

## Fix

Add `+ core::ops::DerefMut` to both call sites' `rng` parameter
bounds:

```rust
pub fn is_probably_prime(
    &self,
    _reps: u32,
    rng: &mut (impl rand_core::RngCore + core::ops::DerefMut),
) -> IsPrime { ... }

pub fn generate_prime(
    rng: &mut (impl rand_core::RngCore + core::ops::DerefMut),
    bit_size: u32,
) -> Self { ... }
```

This is exactly the suggestion `rustc --explain E0277` emits, and
no cryptographic operation is modified — the diff is a trait-system
bound widening only.

## Test plan

- [x] `cargo build` against `glass_pumpkin = "1.10"` succeeds with the
      patch applied.
- [x] `cargo build` against `glass_pumpkin = "1.8"` (pre-rand_core-0.9
      shape) still succeeds — the bound widening is backward-compatible
      since `&mut R` for any `R: ?Sized` already satisfies `DerefMut`.
- [x] Downstream consumer test: `cggmp24 = "0.7.0-alpha.4"` (LFDT-
      Lockness/cggmp21 git rev `63cedd6b`) compiles end-to-end with
      this patch applied via a `[patch.crates-io] fast-paillier = ...`
      override; the CGGMP24 3-of-5 threshold-ECDSA exit gate produces
      a signature that `k256::ecdsa::VerifyingKey::verify_prehash`
      accepts against the joint public key (test source available on
      request).

Closes #23.

---

Authored from gpgo's fork at <https://github.com/gpgo/fast-paillier/tree/fix-glass-pumpkin-1.10-rng-bound>.
The patch has been live in our (Halcyx) workspace as a vendored copy
since 2026-04-30 (BUG-0002 there); upstreaming so we can drop the
vendor on the next release of `fast-paillier` + `cggmp24` that
depends on the new shape.