### PR TITLE
perf(num-bigint): accelerate modular hot operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu-base"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a4867772ef92740ddb786be2aa7407f6588c2f5713cfa3e7ec747dc3a8a221"
+
+[[package]]
+name = "dashu-int"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09237178fe9f89615eb6ba5516fc8c061a4fb203e9550f823f8fbcc4c30e3520"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,11 +272,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fast-paillier"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "bytemuck",
  "ciborium",
  "criterion",
+ "dashu-int",
  "glass_pumpkin",
  "libpaillier",
  "num-bigint",
@@ -433,6 +453,12 @@ checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-modular"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
 
 [[package]]
 name = "num-traits"
@@ -706,6 +732,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bytemuck = { version = "1.5", features = ["derive"], optional = true }
 num-bigint = { version = "0.4.6", optional = true, default-features = false, features = ["rand"] }
 num-traits = { version = "0.2.19", optional = true, default-features = false }
 num-integer = { version = "0.1.46", optional = true, default-features = false }
+dashu-int = { version = "0.5", optional = true, default-features = false }
 glass_pumpkin = { version = "1.8", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 
@@ -52,7 +53,7 @@ serde = ["dep:serde"]
 quickcheck = ["dep:quickcheck"]
 
 backend-rug = ["dep:rug", "dep:bytemuck"]
-backend-num-bigint = ["dep:num-bigint", "dep:num-traits", "dep:num-integer", "dep:glass_pumpkin", "dep:rand"]
+backend-num-bigint = ["dep:num-bigint", "dep:num-traits", "dep:num-integer", "dep:dashu-int", "dep:glass_pumpkin", "dep:rand"]
 
 [[bench]]
 name = "comparison"

--- a/src/backend/num_bigint.rs
+++ b/src/backend/num_bigint.rs
@@ -3,6 +3,7 @@
 use alloc::{string::String, vec::Vec};
 
 use super::IsPrime;
+use dashu_int::{monty::MontgomeryRepr, ops::Gcd as _, UBig};
 use num_integer::Integer as _;
 use num_traits::Signed as _;
 
@@ -122,7 +123,11 @@ impl Integer {
         Integer(self.0.lcm(&other.0))
     }
     pub fn gcd_ref(&self, other: &Self) -> Self {
-        Integer(self.0.gcd(&other.0))
+        if self.significant_bits().max(other.significant_bits()) < 256 {
+            Integer(self.0.gcd(&other.0))
+        } else {
+            from_dashu((&to_dashu(&self.0)).gcd(&to_dashu(&other.0)))
+        }
     }
 
     pub fn cmp0(&self) -> core::cmp::Ordering {
@@ -143,11 +148,28 @@ impl Integer {
         self.pow_mod_ref(exponent, modulo)
     }
     pub fn pow_mod_ref(&self, exponent: &Self, modulo: &Self) -> Option<Self> {
-        let r = if exponent.0.is_negative() {
-            let nself = self.0.modinv(&modulo.0)?;
-            Integer(nself.modpow(&-&exponent.0, &modulo.0))
+        let r = if modulo > &Integer::one() && !modulo.is_even() {
+            let ring = MontgomeryRepr::new(to_dashu(&modulo.0));
+            let base = if self.cmp0().is_ge() && self < modulo {
+                to_dashu(&self.0)
+            } else {
+                to_dashu(&self.modulo_ref(modulo).0)
+            };
+            let base = ring.reduce(base);
+            let base = if exponent.0.is_negative() {
+                base.inv()?
+            } else {
+                base
+            };
+            from_dashu(base.pow(&to_dashu(&exponent.0)).residue())
         } else {
-            Integer(self.0.modpow(&exponent.0, &modulo.0))
+            let value = if exponent.0.is_negative() {
+                let nself = self.0.modinv(&modulo.0)?;
+                nself.modpow(&-&exponent.0, &modulo.0)
+            } else {
+                self.0.modpow(&exponent.0, &modulo.0)
+            };
+            Integer(value)
         };
         // Rug always produces a positive result here. Num-bigint always
         // produces a result between zero and modulo. When modulo is negative,
@@ -213,7 +235,17 @@ impl Integer {
         self.invert_ref(modulo)
     }
     pub fn invert_ref(&self, modulo: &Self) -> Option<Self> {
-        let r = self.0.modinv(&modulo.0).map(Integer)?;
+        let r = if modulo > &Integer::one() && !modulo.is_even() {
+            let ring = MontgomeryRepr::new(to_dashu(&modulo.0));
+            let value = if self.cmp0().is_ge() && self < modulo {
+                to_dashu(&self.0)
+            } else {
+                to_dashu(&self.modulo_ref(modulo).0)
+            };
+            from_dashu(ring.reduce(value).inv()?.residue())
+        } else {
+            self.0.modinv(&modulo.0).map(Integer)?
+        };
         // Rug always produces a positive result here. Num-bigint always
         // produces a result between zero and modulo. When modulo is negative,
         // adjust by it to obtain a result identical to rug
@@ -340,6 +372,14 @@ impl Integer {
         let r = (l_to_le * r_to_re).modulo(self);
         Some(r)
     }
+}
+
+fn to_dashu(value: &num_bigint::BigInt) -> UBig {
+    UBig::from_be_bytes(&value.magnitude().to_bytes_be())
+}
+
+fn from_dashu(value: UBig) -> Integer {
+    Integer::from_bytes_msf(&value.to_be_bytes())
 }
 
 /// Computes jacobi symbol of `a` over `n` multiplied at `mult`


### PR DESCRIPTION
## Summary
- use Dashu Montgomery arithmetic for large odd-modulus exponentiation and inversion
- use Dashu binary GCD for integers at least 256 bits
- preserve num-bigint fallbacks for small, even, unit, and negative moduli

## Performance
On the downstream 130-test signer integration suite, this backend reduced aggregate user CPU from 325.14s to 223.17s (31.4%). Combined with reusable Paillier multiexponentiation contexts it reached 210.10s median (35.4% below baseline).

## Validation
- 2,260 differential cases against fast-paillier 0.3.2
- downstream 28 paillier-zk unit tests and 6 doctests
- downstream 130-test integration suite
- `cargo check --lib --no-default-features --features backend-num-bigint,no_std`
- `cargo clippy --lib --no-default-features --features backend-num-bigint,std -- -D warnings`

All added runtime dependencies are MIT OR Apache-2.0. The implementation remains variable-time, matching the existing num-bigint backend security model.

Signed-off-by: Noah <noah@dfns.co>